### PR TITLE
Refine SEE threshold for capture pruning.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -72,6 +72,16 @@ namespace {
     return Value((175 - 50 * improving) * d / ONE_PLY);
   }
 
+  // Margin for pruning capturing moves: almost linear in depth
+  constexpr int CapturePruneMargin[] = { 0,
+                                         1 * PawnValueEg * 1055 / 1000,
+                                         2 * PawnValueEg * 1042 / 1000,
+                                         3 * PawnValueEg * 963  / 1000,
+                                         4 * PawnValueEg * 1038 / 1000,
+                                         5 * PawnValueEg * 950  / 1000,
+                                         6 * PawnValueEg * 930  / 1000
+                                       };
+
   // Futility and reductions lookup tables, initialized at startup
   int FutilityMoveCounts[2][16]; // [improving][depth]
   int Reductions[2][2][64][64];  // [pv][improving][depth][moveNumber]
@@ -919,7 +929,7 @@ moves_loop: // When in check, search starts from here
           }
           else if (    depth < 7 * ONE_PLY
                    && !extension
-                   && !pos.see_ge(move, -PawnValueEg * (depth / ONE_PLY)))
+                   && !pos.see_ge(move, -Value(CapturePruneMargin[depth / ONE_PLY])))
                   continue;
       }
 


### PR DESCRIPTION
eloDoc suggests that this part of search is worth ~18 Elo.
This patch refines the depth dependence of the SEE threshold.

passed STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 21398 W: 4474 L: 4245 D: 12679
http://tests.stockfishchess.org/tests/view/5abfb0630ebc591a560aae07

passed LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 9028 W: 1439 L: 1285 D: 6304
http://tests.stockfishchess.org/tests/view/5abfbff30ebc591a560aae11

Closes https://github.com/official-stockfish/Stockfish/pull/1527

Bench: 6036915