### PR TITLE
King proximity tweak for passed pawns(Merge master into RazorQSD2)

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -602,8 +602,8 @@ namespace {
             Square blockSq = s + Up;
 
             // Adjust bonus based on the king's proximity
-            bonus += make_score(0, (  king_proximity(Them, blockSq) * 5
-                                    - king_proximity(Us,   blockSq) * 2) * w);
+            bonus += make_score(0, (  (king_proximity(Them, blockSq) * 19) / 4
+                                     - king_proximity(Us,   blockSq) *  2) * w);
 
             // If blockSq is not the queening square then consider also a second push
             if (r != RANK_7)


### PR DESCRIPTION
Decrease slightly the penalty for opponent king distance to passed pawn.
Instead of 5:2 ratio (or 20:8) we now have 19:8

STC
http://tests.stockfishchess.org/tests/view/5de281b2727dc1d26718a673
LLR: 2.95 (-2.94,2.94) [-1.50,4.50]
Total: 28638 W: 6297 L: 6104 D: 16237

LTC
http://tests.stockfishchess.org/tests/view/5de2a2ff727dc1d26718a67b
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 59586 W: 9766 L: 9429 D: 40391

Where to go from here:
Further tests will try a similar tweak on the friendly king proximity penalty,
because recent experiments indicate that this penalty is quite sensitive,
but I wanted to try first on the larger term.

Closes https://github.com/official-stockfish/Stockfish/pull/2435

bench: 5258928

---------------

Increasing the penalty ratio to 21:8 was neutral.
http://tests.stockfishchess.org/tests/view/5de2814d727dc1d26718a671

Decreasing the penalty ratio a bit more to 9:4 seems less promising
http://tests.stockfishchess.org/tests/view/5de2f4c2727dc1d26718a691
http://tests.stockfishchess.org/tests/view/5de32ecc727dc1d26718a6b0