### PR TITLE
Tweak RestrictedPiece bonus

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -520,11 +520,11 @@ namespace {
     }
 
     // Bonus for restricting their piece moves
+    // Greater bonus when landing square is occupied
     b =   attackedBy[Them][ALL_PIECES]
        & ~stronglyProtected
        &  attackedBy[Us][ALL_PIECES];
-
-    score += RestrictedPiece * popcount(b);
+    score += RestrictedPiece * (popcount(b) + popcount(b & pos.pieces()));
 
     // Protected or unattacked squares
     safe = ~attackedBy[Them][ALL_PIECES] | attackedBy[Us][ALL_PIECES];


### PR DESCRIPTION
Double the "RestrictedPiece" bonus for restricted moves targeting
occupied squares.

STC LLR: 3.58 (-2.94,2.94) {-1.00,3.00}
    Total: 25504 W: 4887 L: 4697 D: 15920
    Ptnml(0-2): 387, 2935, 5947, 3051, 422
    https://tests.stockfishchess.org/tests/view/5e2aa15dab2d69d58394f94d

LTC LLR: 2.94 (-2.94,2.94) {0.00,2.00}
    Total: 28572 W: 3826 L: 3621 D: 21125
    Ptnml(0-2): 224, 2609, 8403, 2791, 239
    https://tests.stockfishchess.org/tests/view/5e2ae7f4ab2d69d58394f9a6

Bench: 4719086